### PR TITLE
fix(da-DK): add missing name.entity

### DIFF
--- a/locale/da-DK/name.entity
+++ b/locale/da-DK/name.entity
@@ -1,0 +1,12 @@
+# Eksempler på titler en optagelse kan gemmes under. {name}-feltet er frit;
+# disse værdier lærer kun motoren hvor feltet sidder i en sætning.
+stemmenotat
+møde
+interview
+øvning
+sangidé
+øvesession
+forelæsning
+podcast-episode
+bandøvelse
+guitarriff


### PR DESCRIPTION
locale/da-DK had no `name.entity` file at all. It is a free-form slot (per the English source comment, the values only teach the engine where the slot sits in an utterance), so exact wording is not critical - added natural Danish example recording titles matching the source list 1:1.

Found while doing a coverage review across all skills via ovos-localize.