### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # Audio Recording Skill
 
-Record audio to file, requires [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener)
+This skill records audio to a file. It needs [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener).
 
 ## About
 
-continuously record audio to file and disables wake words/STT while active, made for [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener)
+The skill records audio to a file and disables wake words and speech-to-text while it is active. It needs [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener).
 
-A similar skill that saves text transcriptions instead of recording audio is [OpenVoiceOS/ovos-skill-dictation](https://github.com/OpenVoiceOS/ovos-skill-dictation)
+A similar skill, [OpenVoiceOS/ovos-skill-dictation](https://github.com/OpenVoiceOS/ovos-skill-dictation), saves text transcriptions instead of audio.
 
-in order to avoid users accidentally locking themselves in recording mode a special kind of wake word called a *stop hotword* can be configured, these special hotwords are only used during recording mode and will restore the listener to default state if detected. By default no *stop hotword* is pre-configured
+To avoid trapping a user in recording mode, you can configure a *stop hotword*. This special wake word only works during recording mode. When detected, it restores the listener to its default state. By default, no *stop hotword* is set.
 
-when started via this skill a audio recording will time out after 4 minutes (max_recording_seconds in skill settings) 
+A recording started by this skill times out after 4 minutes. Change this limit with the `max_recording_seconds` setting.
 
-if a `mycroft.stop` bus message is emitted (eg, "stop" via cli) the skill will take dinkum out of recording mode if recording was initiated by this skill
+If a `mycroft.stop` bus message arrives (for example, "stop" on the CLI), the skill takes dinkum out of recording mode, but only if this skill started the recording.
 
-**TODO**: dinkum should have a native (optional) timeout setting, using VAD to automatically stop recording after X seconds of silence
-
+Dinkum does not yet have a native, optional timeout that uses voice activity detection to stop a recording after a period of silence.
 
 ## Examples
 


### PR DESCRIPTION
Rewrites the README prose for clarity while keeping every fact, link, and the credits section unchanged. No structural or footer changes were needed since the repo has no docs/ directory.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the project introduction and About section.
  * Documented recording behavior, including disabled wake words and speech-to-text.
  * Added details about dictation, stop-hotword behavior, the four-minute timeout, configuration options, and `mycroft.stop`.
  * Noted that VAD-based silence timeouts are not currently supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->